### PR TITLE
Enable override fallbacktype on preview

### DIFF
--- a/Classes/Middleware/LanguageFallbacktypeResolver.php
+++ b/Classes/Middleware/LanguageFallbacktypeResolver.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 
 /**
  * Set language fallback type by page field.
@@ -72,6 +73,9 @@ class LanguageFallbacktypeResolver implements MiddlewareInterface
     {
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('pages');
+        $queryBuilder
+            ->getRestrictions()
+            ->removeByType(HiddenRestriction::class);
         $rows = $queryBuilder
             ->select('fallbackType')
             ->from('pages')


### PR DESCRIPTION
As querybuilder automatically not matches hidden elements the override is not working for previews. So i've removed the HiddenRestriction from the querybuilder to make it also work in preview mode.